### PR TITLE
feature/56 - 게시글 API 수정

### DIFF
--- a/youtugo-application/src/main/java/org/nexters/az/post/controller/PostController.java
+++ b/youtugo-application/src/main/java/org/nexters/az/post/controller/PostController.java
@@ -154,6 +154,7 @@ public class PostController {
     private List<DetailedPost> detailedPostsOf(List<Post> posts, Long userId) {
         List<DetailedPost> detailedPosts = new ArrayList<>();
         posts.forEach(post -> detailedPosts.add(detailedPostOf(post, userId)));
+        detailedPosts.forEach(DetailedPost::makeSimpleContent);
 
         return detailedPosts;
     }

--- a/youtugo-application/src/main/java/org/nexters/az/post/controller/PostController.java
+++ b/youtugo-application/src/main/java/org/nexters/az/post/controller/PostController.java
@@ -4,7 +4,6 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.nexters.az.auth.security.TokenSubject;
 import org.nexters.az.auth.service.AuthService;
-import org.nexters.az.comment.service.CommentService;
 import org.nexters.az.common.dto.CurrentPageAndPageSize;
 import org.nexters.az.common.dto.SimplePage;
 import org.nexters.az.common.validation.PageValidation;
@@ -29,7 +28,6 @@ import java.util.List;
 @RequestMapping("v1/api/posts")
 public class PostController {
     private final PostService postService;
-    private final CommentService commentService;
     private final AuthService authService;
 
     @ApiOperation("게시글 작성")
@@ -47,7 +45,7 @@ public class PostController {
                 .build();
         post = postService.create(post);
 
-        return new WritePostResponse(detailedPostOf(post, user.getId()));
+        return new WritePostResponse(postService.detailedPostOf(post, user.getId()));
     }
 
     @ApiOperation("게시글들 조회")
@@ -115,7 +113,7 @@ public class PostController {
             userId = authService.findUserIdBy(accessToken, TokenSubject.ACCESS_TOKEN);
         }
 
-        DetailedPost detailedPost = detailedPostOf(postService.getPost(postId), userId);
+        DetailedPost detailedPost = postService.detailedPostOf(postService.getPost(postId), userId);
 
         return new GetPostResponse(detailedPost);
     }
@@ -148,47 +146,15 @@ public class PostController {
 
         Post post = postService.insertLikeInPost(user, postId);
 
-        return new GetPostResponse(detailedPostOf(post, user.getId()));
+        return new GetPostResponse(postService.detailedPostOf(post, user.getId()));
    }
 
     private List<DetailedPost> detailedPostsOf(List<Post> posts, Long userId) {
         List<DetailedPost> detailedPosts = new ArrayList<>();
-        posts.forEach(post -> detailedPosts.add(detailedPostOf(post, userId)));
+        posts.forEach(post -> detailedPosts.add(postService.detailedPostOf(post, userId)));
         detailedPosts.forEach(DetailedPost::makeSimpleContent);
 
         return detailedPosts;
-    }
-
-    private DetailedPost detailedPostOf(Post post, Long userId) {
-        DetailedPost detailedPost = new DetailedPost(post);
-        detailedPost.setLikes(findPostLikeCount(post.getId()));
-        detailedPost.setComments(findPostCommentCount(post.getId()));
-        detailedPost.setBookMarks(findPostBookmarkCount(post.getId()));
-        if (userId != null)
-            detailedPost.setPressLike(checkUserPressLike(userId, post.getId()));
-
-        return detailedPost;
-    }
-
-    private int findPostLikeCount(Long postId) {
-        return postService.countPostLike(postId);
-    }
-
-    private int findPostCommentCount(Long postId) {
-        return commentService.findCommentCount(postId);
-    }
-
-    private int findPostBookmarkCount(Long postId) {
-        /**
-         * @author : 최민성
-         * @Param : 게시글 id
-         * @retrun : bookmark 개수
-         */
-        return 0;
-    }
-
-    private boolean checkUserPressLike(Long userId, Long postId) {
-        return postService.checkUserPressLike(userId, postId);
     }
 
 }

--- a/youtugo-application/src/main/java/org/nexters/az/user/controller/UserController.java
+++ b/youtugo-application/src/main/java/org/nexters/az/user/controller/UserController.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.nexters.az.auth.security.TokenSubject;
 import org.nexters.az.auth.service.AuthService;
 import org.nexters.az.comment.response.GetCommentsResponse;
-import org.nexters.az.comment.service.CommentService;
 import org.nexters.az.common.dto.CurrentPageAndPageSize;
 import org.nexters.az.common.dto.SimplePage;
 import org.nexters.az.common.validation.PageValidation;
@@ -37,7 +36,6 @@ import java.util.stream.Stream;
 public class UserController {
     private final UserService userService;
     private final AuthService authService;
-    private final CommentService commentService;
     private final PostService postService;
     private final PostBookMarkService postBookMarkService;
 
@@ -104,7 +102,7 @@ public class UserController {
 
         Post post = postBookMarkService.insertBookMarkInPost(user, postId);
 
-        return new GetPostResponse(detailedPostOf(post, user.getId()));
+        return new GetPostResponse(postService.detailedPostOf(post, user.getId()));
     }
 
     @ApiOperation("게시글 북마크 취소")
@@ -147,21 +145,12 @@ public class UserController {
         }
     }
 
-    public DetailedPost detailedPostOf(Post post, Long userId) {
-        DetailedPost detailedPost = new DetailedPost(post);
-        detailedPost.setLikes(postService.countPostLike(post.getId()));
-        detailedPost.setBookMarks(postBookMarkService.countPostBookMark(post.getId()));
-        detailedPost.setLikes(commentService.findCommentCount(post.getId()));
-        detailedPost.setPressLike(postService.checkUserPressLike(userId, post.getId()));
-
-        return detailedPost;
-    }
-
     private List<DetailedPost> detailedPostsOf(Stream<PostBookMark> postBookMarks, Long userId) {
-
         List<DetailedPost> detailedPosts = new ArrayList<>();
-        postBookMarks.forEach(post -> detailedPosts.add(detailedPostOf(post.getPost(), userId)));
+        postBookMarks.forEach(post -> detailedPosts.add(postService.detailedPostOf(post.getPost(), userId)));
+        detailedPosts.forEach(DetailedPost::makeSimpleContent);
 
         return detailedPosts;
     }
+
 }

--- a/youtugo-domain/src/main/java/org/nexters/az/post/dto/DetailedPost.java
+++ b/youtugo-domain/src/main/java/org/nexters/az/post/dto/DetailedPost.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.nexters.az.post.entity.Post;
+import org.nexters.az.user.dto.SimpleUser;
 
 import java.time.LocalDateTime;
 
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class DetailedPost {
     private Long id;
-    private String authorNickname;
+    private SimpleUser author;
     private String content;
     private int likes;
     private int bookMarks;
@@ -27,7 +28,7 @@ public class DetailedPost {
 
     public DetailedPost(Post post) {
         this.id = post.getId();
-        this.authorNickname = post.getAuthor().getNickname();
+        this.author = SimpleUser.of(post.getAuthor());
         this.content = post.getContent();
         this.createdDate = post.getCreatedDate();
         this.modifiedDate = post.getModifiedDate();
@@ -48,5 +49,9 @@ public class DetailedPost {
 
     public void setComments(int comments) {
         this.comments = comments;
+    }
+
+    public void makeSimpleContent() {
+        content = content.replace('\n', ' ').replaceAll("( )+", " ");
     }
 }

--- a/youtugo-domain/src/main/java/org/nexters/az/post/service/PostService.java
+++ b/youtugo-domain/src/main/java/org/nexters/az/post/service/PostService.java
@@ -1,11 +1,11 @@
 package org.nexters.az.post.service;
 
 import lombok.RequiredArgsConstructor;
+import org.nexters.az.comment.repository.CommentRepository;
+import org.nexters.az.post.dto.DetailedPost;
 import org.nexters.az.post.entity.Post;
-import org.nexters.az.post.entity.PostBookMark;
 import org.nexters.az.post.entity.PostLike;
 import org.nexters.az.post.exception.NonExistentPostException;
-import org.nexters.az.post.exception.UserAlreadyPressBookMarkException;
 import org.nexters.az.post.exception.UserAlreadyPressLikeException;
 import org.nexters.az.post.repository.PostBookMarkRepository;
 import org.nexters.az.post.repository.PostLikeRepository;
@@ -23,6 +23,19 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
     private final PostBookMarkRepository postBookMarkRepository;
+    private final CommentRepository commentRepository;
+
+    public DetailedPost detailedPostOf(Post post, Long userId) {
+        DetailedPost detailedPost = new DetailedPost(post);
+        detailedPost.setLikes(countPostLike(post.getId()));
+        detailedPost.setBookMarks(postBookMarkRepository.countPostBookMarksByPostId(post.getId()));
+        detailedPost.setComments(commentRepository.countAllByPostId(post.getId()));
+        if (userId != null) {
+            detailedPost.setPressLike(checkUserPressLike(userId, post.getId()));
+        }
+
+        return detailedPost;
+    }
 
     public Post insertLikeInPost(User user, Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(NonExistentPostException::new);


### PR DESCRIPTION
작성자 : 최민성
 
- 게시글 정보에 SimpleUser 정보 추가
- 게시글 리스트에서 content 보이는 방식 수정
    - 연속된 개행,연속된 공백을 공백하나로 처리
- 중복 코드 리팩토링