### PR TITLE
feature/56 - 회원가입 버그 픽스

### DIFF
--- a/youtugo-application/src/test/java/org/nexters/az/common/CommonTest.java
+++ b/youtugo-application/src/test/java/org/nexters/az/common/CommonTest.java
@@ -120,8 +120,8 @@ public abstract class CommonTest {
         testNO++;
 
         return new SignUpRequest(
-                "test" + testNO,
-                "test" + testNO,
+                "testID" + testNO,
+                "testNick" + testNO,
                 COMMON_PW
         );
     }

--- a/youtugo-domain/src/main/java/org/nexters/az/user/service/UserService.java
+++ b/youtugo-domain/src/main/java/org/nexters/az/user/service/UserService.java
@@ -25,8 +25,8 @@ public class UserService {
     private final CommentRepository commentRepository;
 
     public User signUp(User user) {
-        checkUserNicknameExist(user.getIdentification());
-        checkUserIdentificationExist(user.getNickname());
+        checkUserNicknameExist(user.getNickname());
+        checkUserIdentificationExist(user.getIdentification());
         user.setHashedPassword(SHA256Util.of(user.getHashedPassword()));
         return userRepository.save(user);
     }


### PR DESCRIPTION
작성자 : 최민성
 
- 회원가입시 중복체크가 안되는 버그 확인
    - 내부적으로 닉네임/아이디 를 반대로 검사하고있었음